### PR TITLE
Changed `clobber` keyword to `overwrite` in `total_model`

### DIFF
--- a/raytrace.py
+++ b/raytrace.py
@@ -329,7 +329,7 @@ def total_model(disk,imres=0.05,distance=122.,chanmin=-2.24,nchans=15,chanstep=0
         imt_s = ndimage.shift(imt_s,(pixshift[0],pixshift[1],0),mode='nearest')        
         hdut=fits.PrimaryHDU((imt_s/disk.AU).T,hdrt)
         #hdut=fits.PrimaryHDU((imt_s).T,hdrt)
-        hdut.writeto(modfile+'p_tau1.fits',clobber=True,output_verify='fix')
+        hdut.writeto(modfile+'p_tau1.fits',overwrite=True,output_verify='fix')
                     
     
     # - interpolate onto a square grid
@@ -368,7 +368,7 @@ def total_model(disk,imres=0.05,distance=122.,chanmin=-2.24,nchans=15,chanstep=0
 
     # write processed model
     hdu = fits.PrimaryHDU(im_s.T,hdr)
-    hdu.writeto(modfile+'.fits',clobber=True,output_verify='fix')
+    hdu.writeto(modfile+'.fits',overwrite=True,output_verify='fix')
     
 
 


### PR DESCRIPTION
Changed the `clobber` keyword to `overwrite` in accordance with the newer versions of `astropy`, since `clobber` has been deprecated and will not be used in the future.

This prevents the command line from spouting an angry warning about the issue while running the code.